### PR TITLE
Upgrade to Gym 0.21

### DIFF
--- a/advanced_saving_loading.ipynb
+++ b/advanced_saving_loading.ipynb
@@ -97,7 +97,7 @@
         "\n",
         "\"The inverted pendulum swingup problem is a classic problem in the control literature. In this version of the problem, the pendulum starts in a random position, and the goal is to swing it up so it stays upright.\"\n",
         "\n",
-        "Pendulum-v0 environment: [https://gym.openai.com/envs/Pendulum-v0/](https://gym.openai.com/envs/Pendulum-v0/)\n",
+        "Pendulum-v1 environment: [documentation (for older but similar version)](https://gym.openai.com/envs/Pendulum-v0/), [source code](https://github.com/openai/gym/blob/master/gym/envs/classic_control/pendulum.py)\n",
         "\n",
         "![Pendulum](https://gym.openai.com/videos/2019-10-21--mqt8Qj1mwo/Pendulum-v0/poster.jpg)\n",
         "\n",
@@ -131,7 +131,7 @@
         }
       },
       "source": [
-        "model = SAC('MlpPolicy', 'Pendulum-v0', verbose=1, learning_rate=1e-3, create_eval_env=True)"
+        "model = SAC('MlpPolicy', 'Pendulum-v1', verbose=1, learning_rate=1e-3, create_eval_env=True)"
       ],
       "execution_count": 3,
       "outputs": [
@@ -139,8 +139,8 @@
           "output_type": "stream",
           "text": [
             "Using cuda device\n",
-            "Creating environment from the given name 'Pendulum-v0'\n",
-            "Creating environment from the given name 'Pendulum-v0'\n",
+            "Creating environment from the given name 'Pendulum-v1'\n",
+            "Creating environment from the given name 'Pendulum-v1'\n",
             "Wrapping the env in a DummyVecEnv.\n"
           ],
           "name": "stdout"

--- a/advanced_saving_loading.ipynb
+++ b/advanced_saving_loading.ipynb
@@ -318,7 +318,7 @@
         "id": "mogPtE0D90hw"
       },
       "source": [
-        "saved_policy = MlpPolicy.load(\"sac_policy_pendulum\")"
+        "saved_policy = MlpPolicy.load(\"sac_policy_pendulum.pkl\")"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Change occurrences of `Pendulum-v0` to `Pendulum-v1`, and fix one loading bug (needs pkl suffix) in `advanced_saving_loading.ipynb`

I have not verified the other notebooks (perhaps we should make unit tests for them with [pytest-notebook](https://pytest-notebook.readthedocs.io/)?), but I looked at all environment names with regex `-v[0-9]` and all of them seem to still be present in newest Gym. So should work.