### PR TITLE
Do apt update before apt install

### DIFF
--- a/monitor_training.ipynb
+++ b/monitor_training.ipynb
@@ -57,7 +57,7 @@
         "colab": {}
       },
       "source": [
-        "!apt install swig cmake\n",
+    "!apt-get update && apt-get install swig cmake\n",
         "!pip install stable-baselines3[extra] box2d box2d-kengz"
       ],
       "execution_count": 0,

--- a/pretraining.ipynb
+++ b/pretraining.ipynb
@@ -58,7 +58,7 @@
       "outputs": [],
       "source": [
         "# For Box2D env\n",
-        "!apt-get install swig\n",
+    "!apt-get update && apt-get install swig\n",
         "!pip install gym[box2d]\n",
         "!pip install stable-baselines3[extra]"
       ]

--- a/rl-baselines-zoo.ipynb
+++ b/rl-baselines-zoo.ipynb
@@ -40,7 +40,7 @@
       },
       "outputs": [],
       "source": [
-        "!apt-get install swig cmake ffmpeg freeglut3-dev xvfb"
+    "!apt-get update && apt-get install swig cmake ffmpeg freeglut3-dev xvfb"
       ]
     },
     {

--- a/saving_loading_dqn.ipynb
+++ b/saving_loading_dqn.ipynb
@@ -56,7 +56,7 @@
         "id": "gWskDE2c9WoN"
       },
       "source": [
-        "!apt install swig cmake\n",
+    "!apt-get update && apt-get install swig cmake\n",
         "!pip install stable-baselines3[extra] box2d box2d-kengz"
       ],
       "execution_count": null,

--- a/stable_baselines_getting_started.ipynb
+++ b/stable_baselines_getting_started.ipynb
@@ -70,7 +70,7 @@
         "colab": {}
       },
       "source": [
-        "!apt-get install ffmpeg freeglut3-dev xvfb  # For visualization\n",
+    "!apt-get update && apt-get install ffmpeg freeglut3-dev xvfb  # For visualization\n",
         "!pip install stable-baselines3[extra]"
       ],
       "execution_count": 0,

--- a/stable_baselines_wandb.ipynb
+++ b/stable_baselines_wandb.ipynb
@@ -67,7 +67,7 @@
         "id": "47bVDhSDPywL"
       },
       "source": [
-        "!apt install python-opengl xvfb\n",
+    "!apt-get update && apt-get install python-opengl xvfb\n",
         "!pip install pyvirtualdisplay stable_baselines3[extra] wandb\n",
         "from pyvirtualdisplay import Display\n",
         "virtual_display = Display(visible=0, size=(1400, 900))\n",


### PR DESCRIPTION
The colab tutorials where xvfb is installed, are currently broken. This can be fixed by doing apt update before apt install xvfb. To prevent possible future problems, I also added apt update before the other installations.