### PR TITLE
Fix missing new line character in rl-baselines-zoo.ipynb

### DIFF
--- a/rl-baselines-zoo.ipynb
+++ b/rl-baselines-zoo.ipynb
@@ -41,7 +41,7 @@
       "outputs": [],
       "source": [
         "!apt-get update && apt-get install swig cmake ffmpeg freeglut3-dev xvfb\n",
-        "!pip install setuptools==66",
+        "!pip install setuptools==66\n",
         "!pip install pyglet==1.5.27"
       ]
     },


### PR DESCRIPTION
Fixes regression just introduced in https://github.com/Stable-Baselines-Team/rl-colab-notebooks/pull/13/commits/b617331e00e76bdf6359659e64ed488f1d16467f